### PR TITLE
Add ci/cd file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,23 @@
+tages:
+  - build
+  - deploy-production
+
+variables:
+  IMAGE_URL: se_lab_1:$CI_PIPELINE_ID-$CI_COMMIT_SHORT_SHA
+  
+build:
+  stage: build
+  image: docker:19.03.12
+  tags:
+    - docker
+  script:
+    - docker build . -t $IMAGE_URL
+    - docker push $IMAGE_URL
+
+deploy-production:
+  stage: deploy-production
+  image: kroniak/ssh-client:latest
+  before_script:
+    - echo $IMAGE_URL
+  script:
+    - docker run -d --name se_lab_1_container -p80:80 $IMAGE_URL


### PR DESCRIPTION
In order to automating the build
and deploy process, we are using
gitlab-ci. For each change, ci/cd
should build new docker image and
deploy the new version of the project.

CI/CD Stages:
- Build: build docker image using Dockerfile.
- Deploy: deploy the new version of the project and update the current docker image version.